### PR TITLE
DM-48772: Add butler admin update-storage-class command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,62 @@
+name: build_and_test
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need to clone everything for the git tags.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "setup.cfg"
+
+      - name: Update pip/wheel infrastructure
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv pip install --system wheel
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system -r requirements.txt
+
+      # We have two cores so we can speed up the testing with xdist
+      - name: Install pytest packages
+        run: |
+          uv pip install --system pytest pytest-xdist pytest-cov
+
+      - name: List installed packages
+        run: |
+          uv pip list -v
+
+      - name: Build and install
+        run: |
+          uv pip install -v --system --no-deps -e .
+
+      - name: Run tests
+        run: |
+          pytest -r a -v -n 3 --cov=lsst.daf.butler_admin --cov=tests --cov-report=xml --cov-report=term --cov-branch
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ pytest_session.txt
 .cache/
 .pytest_cache
 .coverage
+
+python/lsst_daf_butler_admin.dist-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         args:
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -17,16 +17,16 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.7
+    rev: v0.9.5
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc
-    rev: "v1.7.0"
+    rev: "v1.8.0"
     hooks:
       - id: numpydoc-validation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,25 +7,14 @@ repos:
           - "--unsafe"
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.0
-    hooks:
-      - id: isort
-        name: isort (python)
+      - id: check-toml
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.9.5
     hooks:
       - id: ruff
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/numpy/numpydoc
     rev: "v1.8.0"
     hooks:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,16 @@
+extends: default
+
+rules:
+  document-start: {present: false}
+  line-length:
+    max: 132
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+    ignore: |
+      /.github/workflows/lint.yaml
+  truthy:
+    # "on" as a key in workflows confuses things
+    ignore: |
+      /.github/workflows/
+  indentation:
+    indent-sequences: consistent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.entry-points.'butler.cli']
+daf_butler_admin = "lsst.daf.butler_admin.cli:get_cli_subcommands"
+
 [project.urls]
 "Homepage" = "https://github.com/lsst-dm/daf_butler_admin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ target-version = ["py311"]
 [tool.isort]
 profile = "black"
 line_length = 110
+known_first_party = ["lsst"]
 
 [tool.lsst_versions]
 write_to = "python/lsst/daf/butler_admin/version.py"
@@ -90,8 +91,10 @@ select = [
     "N",  # pep8-naming
     "W",  # pycodestyle
     "D",  # pydocstyle
-    "UP",
-    "C4",
+    "UP", # pyupgrade
+    "C4", # flake8-comprehensions
+    "I",  # isort
+    "RUF022",  # sort __all__
 ]
 extend-select = [
     "RUF100", # Warn about unused noqa
@@ -102,6 +105,14 @@ max-doc-length = 79
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.isort]
+known-first-party = ["lsst"]
+
+[tool.ruff.format]
+docstring-code-format = true
+# Formatter does not know about indenting.
+docstring-code-line-length = 69
 
 [tool.pytest.ini_options]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,10 @@ extend-select = [
     "RUF100", # Warn about unused noqa
 ]
 
-[tool.ruff.pycodestyle]
+[tool.ruff.lint.pycodestyle]
 max-doc-length = 79
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.pytest.ini_options]

--- a/python/lsst/daf/butler_admin/cli/__init__.py
+++ b/python/lsst/daf/butler_admin/cli/__init__.py
@@ -1,0 +1,1 @@
+from ._get_cli_subcommands import get_cli_subcommands

--- a/python/lsst/daf/butler_admin/cli/_get_cli_subcommands.py
+++ b/python/lsst/daf/butler_admin/cli/_get_cli_subcommands.py
@@ -1,0 +1,37 @@
+# This file is part of daf_butler_admin
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ["get_cli_subcommands"]
+
+import click
+
+from . import cmd
+
+
+def get_cli_subcommands() -> list[click.Command]:
+    """Return the location of the CLI command plugin definitions.
+
+    Returns
+    -------
+    commands : `list` [ `click.Command` ]
+        The command-line subcommands provided by this package.
+    """
+    return [getattr(cmd, c) for c in cmd.__all__]

--- a/python/lsst/daf/butler_admin/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_admin/cli/cmd/commands.py
@@ -22,6 +22,7 @@
 from typing import Any
 
 import click
+
 from lsst.daf.butler.cli.opt import repo_argument
 from lsst.daf.butler.cli.utils import ButlerCommand
 

--- a/python/lsst/daf/butler_admin/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_admin/cli/cmd/commands.py
@@ -24,7 +24,7 @@ from typing import Any
 import click
 
 from lsst.daf.butler.cli.opt import repo_argument
-from lsst.daf.butler.cli.utils import ButlerCommand
+from lsst.daf.butler.cli.utils import ButlerCommand, MWArgumentDecorator
 
 from ... import script
 
@@ -44,3 +44,28 @@ def admin() -> None:
 def refresh_collection_summary(**kwargs: Any) -> None:
     """Refresh contents of the collection summary tables."""
     script.refresh_collection_summary(**kwargs)
+
+
+dataset_type_glob_argument = MWArgumentDecorator(
+    "dataset-type",
+    help="DATASET_TYPE is the dataset type name or glob to match multiple dataset types.",
+)
+from_storage_class_argument = MWArgumentDecorator(
+    "storage-class",
+    help="STORAGE_CLASS is the name of the existing storage class in the dataset type.",
+)
+to_storage_class_argument = MWArgumentDecorator(
+    "to-storage-class",
+    help="TO_STORAGE_CLASS is the name of the storage class to assign to matching dataset types.",
+)
+
+
+@admin.command(cls=ButlerCommand)
+@click.option("--update", help="Execute updates, by default only print actions taken.", is_flag=True)
+@repo_argument(required=True)
+@dataset_type_glob_argument(required=True)
+@from_storage_class_argument(required=True)
+@to_storage_class_argument(required=True)
+def update_storage_class(**kwargs: Any) -> None:
+    """Update storage class definition for some dataset types."""
+    script.update_storage_class(**kwargs)

--- a/python/lsst/daf/butler_admin/cli/resources.yaml
+++ b/python/lsst/daf/butler_admin/cli/resources.yaml
@@ -1,4 +1,0 @@
-cmd:
-  import: lsst.daf.butler_admin.cli.cmd
-  commands:
-    - admin

--- a/python/lsst/daf/butler_admin/script/__init__.py
+++ b/python/lsst/daf/butler_admin/script/__init__.py
@@ -20,3 +20,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .refresh_collection_summary import refresh_collection_summary
+from .update_storage_class import update_storage_class

--- a/python/lsst/daf/butler_admin/script/refresh_collection_summary.py
+++ b/python/lsst/daf/butler_admin/script/refresh_collection_summary.py
@@ -1,4 +1,4 @@
-# This file is part of daf_butler_migrate.
+# This file is part of daf_butler_admin.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/lsst/daf/butler_admin/script/update_storage_class.py
+++ b/python/lsst/daf/butler_admin/script/update_storage_class.py
@@ -1,0 +1,130 @@
+# This file is part of daf_butler_admin.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["update_storage_class"]
+
+from lsst.daf.butler import Butler, DatasetType, StorageClass
+from lsst.daf.butler.direct_butler import DirectButler
+from lsst.daf.butler.registry.datasets.byDimensions import ByDimensionsDatasetRecordStorageManagerUUID
+
+
+def update_storage_class(
+    repo: str, update: bool, dataset_type: str, storage_class: str, to_storage_class: str
+) -> None:
+    """Update storage class definition for some dataset types.
+
+    Parameters
+    ----------
+    repo : `str`
+        URI of butler repository to update.
+    update : `bool`
+        Perform actual updates if `True`, print actions otherwise.
+    dataset_type : `str`
+        Dataset type name or glob to match multiple dataset types.
+    storage_class : `str`
+        Name of the existing storage class in the dataset type.
+    to_storage_class : `str`
+        Name of the storage class to assign to matching dataset types.
+    """
+    # Connect to the butler.
+    butler = Butler.from_config(repo, writeable=True)
+    assert isinstance(butler, DirectButler), "This script requires DirectButler."
+
+    try:
+        old_storage_class = butler.storageClasses.getStorageClass(storage_class)
+    except KeyError:
+        raise ValueError(f"Storage class {storage_class} does not exist") from None
+    try:
+        new_storage_class = butler.storageClasses.getStorageClass(to_storage_class)
+    except KeyError:
+        raise ValueError(f"Storage class {to_storage_class} does not exist") from None
+
+    # The code below may need to import Python types, check that it works.
+    _check_import(old_storage_class)
+    _check_import(new_storage_class)
+
+    # Check that storage classes are compatible
+    if not new_storage_class.can_convert(old_storage_class):
+        raise TypeError(f"Storage class {to_storage_class} cannot convert from {storage_class}")
+
+    dataset_types = [
+        ds_type
+        for ds_type in butler.registry.queryDatasetTypes(expression=dataset_type)
+        if ds_type.storageClass.name == storage_class
+    ]
+    if not dataset_types:
+        print("No matching dataset types were found.")
+    elif not update:
+        print("Will update storage class for following dataset types:")
+        for ds_type in dataset_types:
+            print(ds_type)
+    else:
+        _update(butler, dataset_types, to_storage_class)
+
+
+def _check_import(storage_class: StorageClass) -> None:
+    """Check that Python type for this StorageClass can be imported.
+
+    Parameters
+    ----------
+    storage_class : `lsst.daf.butler.StorageClass`
+        Storage class to be checked.
+    """
+    try:
+        storage_class.pytype
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Import failed for Python type of storage class {storage_class}."
+            " Please make sure that corresponding package is set up."
+        ) from exc
+
+
+def _update(butler: DirectButler, dataset_types: list[DatasetType], storage_class: str) -> None:
+    """Update database definition of dataset types with new storage class.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.DirectButler`
+        Data butler to be updated.
+    dataset_types : `list` [`lsst.daf.butler.DatasetType`]
+        List of data set types to update.
+    storage_class : `str`
+        Name of the storage class.
+
+    Notes
+    -----
+    There is no Butler or Registry interface for this operation, this has to be
+    done using their internals.
+    """
+    # We need SqlRegistry.
+    registry = butler._registry
+    dataset_manager = registry._managers.datasets
+    assert isinstance(dataset_manager, ByDimensionsDatasetRecordStorageManagerUUID), (
+        "Unexpected type of dataset manager"
+    )
+
+    dataset_type_table = dataset_manager._static.dataset_type
+
+    rows = [{"ds_name": ds_type.name, "storage_class": storage_class} for ds_type in dataset_types]
+    count = registry._db.update(dataset_type_table, {"name": "ds_name"}, *rows)
+    print(f"Updated {count} dataset type record{'' if count == 1 else 's'} in database.")

--- a/tests/test_update_storage_class.py
+++ b/tests/test_update_storage_class.py
@@ -1,0 +1,132 @@
+# This file is part of daf_butler_admin.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import tempfile
+import unittest
+
+from lsst.daf.butler import Butler, DatasetType, DimensionGroup
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+from lsst.daf.butler_admin.script import update_storage_class
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class TestUpdateStorageClass(unittest.TestCase):
+    """Test case for update_storage_class script."""
+
+    def setUp(self) -> None:
+        self.root = makeTestTempDir(TESTDIR)
+
+    def tearDown(self) -> None:
+        removeTestTempDir(self.root)
+
+    def make_butler(self) -> str:
+        """Make a Butler instance with universe of specific version."""
+        butler_root = tempfile.mkdtemp(dir=self.root)
+        Butler.makeRepo(butler_root)
+        return butler_root
+
+    def test_update(self) -> None:
+        """Create few dataset types and update their storage class."""
+        butler_root = self.make_butler()
+
+        # Register few dataset types. For this test we want to use storage
+        # classes that do not require setting up additional packages.
+        butler = Butler.from_config(butler_root, writeable=True)
+        dimensions = DimensionGroup(butler.dimensions)
+        initial_storage_classes = {
+            "a_metadata": "StructuredDataDict",
+            "b_other": "StructuredDataDict",
+            "c_metadata": "StructuredDataDict",
+        }
+
+        for name, storage_class in initial_storage_classes.items():
+            butler.registry.registerDatasetType(
+                DatasetType(name=name, dimensions=dimensions, storageClass=storage_class)
+            )
+
+        # Check storage classes.
+        for name, storage_class in initial_storage_classes.items():
+            self.assertEqual(butler.get_dataset_type(name).storageClass.name, storage_class)
+
+        # Update one.
+        update_storage_class(
+            repo=butler_root,
+            update=True,
+            dataset_type="*_metadata",
+            storage_class="StructuredDataDict",
+            to_storage_class="Packages",
+        )
+
+        # Need new Butler instance to avoid caching issues.
+        butler = Butler.from_config(butler_root, writeable=True)
+
+        new_storage_classes = {
+            "a_metadata": "Packages",
+            "b_other": "StructuredDataDict",
+            "c_metadata": "Packages",
+        }
+        for name, storage_class in new_storage_classes.items():
+            self.assertEqual(butler.get_dataset_type(name).storageClass.name, storage_class)
+
+        # Update everything.
+        update_storage_class(
+            repo=butler_root,
+            update=True,
+            dataset_type="*",
+            storage_class="StructuredDataDict",
+            to_storage_class="Packages",
+        )
+
+        butler = Butler.from_config(butler_root, writeable=True)
+
+        new_storage_classes = {
+            "a_metadata": "Packages",
+            "b_other": "Packages",
+            "c_metadata": "Packages",
+        }
+        for name, storage_class in new_storage_classes.items():
+            self.assertEqual(butler.get_dataset_type(name).storageClass.name, storage_class)
+
+        # Non-convertible classes.
+        with self.assertRaisesRegex(TypeError, "Storage class ButlerLogRecords cannot convert from Packages"):
+            update_storage_class(
+                repo=butler_root,
+                update=True,
+                dataset_type="*",
+                storage_class="Packages",
+                to_storage_class="ButlerLogRecords",
+            )
+
+        # Unknown class name.
+        with self.assertRaisesRegex(ValueError, "Storage class NotAClass does not exist"):
+            update_storage_class(
+                repo=butler_root,
+                update=True,
+                dataset_type="*",
+                storage_class="Packages",
+                to_storage_class="NotAClass",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ups/daf_butler_admin.table
+++ b/ups/daf_butler_admin.table
@@ -2,4 +2,3 @@ setupRequired(daf_butler)
 setupRequired(sconsUtils)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
-envPrepend(DAF_BUTLER_PLUGINS, ${PRODUCT_DIR}/python/lsst/daf/butler_admin/cli/resources.yaml)


### PR DESCRIPTION
It allows to change storage class associated with a selection of
dataset types. Before applying this change the script verifies that
old storage class can be converted to a new one.

Also remove isort/black checks replacing them with ruff, following what was done to daf_butler.