### PR TITLE
DM-50727: Add empty-trash admin command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bin/
 
 # Pytest
 tests/.tests
+tests/tmp*
 pytest_session.txt
 .cache/
 .pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ pytest_session.txt
 .pytest_cache
 .coverage
 
+_build.*
+
 python/lsst_daf_butler_admin.dist-info/

--- a/python/lsst/daf/butler_admin/cli/cmd/commands.py
+++ b/python/lsst/daf/butler_admin/cli/cmd/commands.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import click
 
-from lsst.daf.butler.cli.opt import repo_argument
+from lsst.daf.butler.cli.opt import repo_argument, verbose_option
 from lsst.daf.butler.cli.utils import ButlerCommand, MWArgumentDecorator
 
 from ... import script
@@ -69,3 +69,14 @@ to_storage_class_argument = MWArgumentDecorator(
 def update_storage_class(**kwargs: Any) -> None:
     """Update storage class definition for some dataset types."""
     script.update_storage_class(**kwargs)
+
+
+@admin.command(cls=ButlerCommand)
+@repo_argument(required=True)
+@verbose_option(help="Report URIs of removed artifacts.")
+@click.option(
+    "--dry-run/--no-dry-run", default=False, help="Enable dry run mode and do not delete any datasets."
+)
+def empty_trash(**kwargs: Any) -> None:
+    """Force the trash table to be emptied."""
+    script.empty_trash(**kwargs)

--- a/python/lsst/daf/butler_admin/script/__init__.py
+++ b/python/lsst/daf/butler_admin/script/__init__.py
@@ -19,5 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from .empty_trash import empty_trash
 from .refresh_collection_summary import refresh_collection_summary
 from .update_storage_class import update_storage_class

--- a/python/lsst/daf/butler_admin/script/empty_trash.py
+++ b/python/lsst/daf/butler_admin/script/empty_trash.py
@@ -1,0 +1,59 @@
+# This file is part of daf_butler_admin.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["empty_trash"]
+
+
+import logging
+
+from lsst.daf.butler import Butler
+
+_LOG = logging.getLogger(__name__)
+
+
+def empty_trash(repo: str, verbose: bool, dry_run: bool) -> None:
+    """Empty the datastore trash table.
+
+    Parameters
+    ----------
+    repo : `str`
+        URI of butler repository to update.
+    verbose : `bool`
+        If `True` report the datasets that were removed.
+    dry_run : `bool`
+        If `True` report how many datasets would be removed but do not
+        remove them.
+    """
+    # Connect to the butler.
+    butler = Butler.from_config(repo, writeable=True)
+
+    try:
+        removed = butler._datastore.emptyTrash(dry_run=dry_run)
+    except AttributeError:
+        print("Butler repository does not have a datastore that can support trash emptying")
+        return
+
+    if verbose and removed:
+        print("Removed the following:")
+        for uri in sorted(removed):
+            print(uri)

--- a/tests/test_empty_trash.py
+++ b/tests/test_empty_trash.py
@@ -1,0 +1,101 @@
+# This file is part of daf_butler_admin.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from lsst.daf.butler import Butler
+from lsst.daf.butler.tests import (
+    DatasetTestHelper,
+    MetricsExample,
+    addDataIdValue,
+    addDatasetType,
+    registerMetricsExample,
+)
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+from lsst.daf.butler_admin.script import empty_trash
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class TestEmptyTrash(unittest.TestCase, DatasetTestHelper):
+    """Test empty-trash script interface."""
+
+    def setUp(self) -> None:
+        self.root = makeTestTempDir(TESTDIR)
+        config = Butler.makeRepo(self.root)
+        self.butler = Butler.from_config(config, run="test")
+
+        self.instruments = [f"cam{n}" for n in range(10)]
+        for inst in self.instruments:
+            addDataIdValue(self.butler, "instrument", inst)
+        registerMetricsExample(self.butler)
+        addDatasetType(self.butler, "metrics", {"instrument"}, "StructuredDataNoComponents")
+
+        self.refs = []
+        for inst in self.instruments:
+            ref = self.makeDatasetRef(
+                "metrics",
+                self.butler.dimensions.conform(("instrument",)),
+                "StructuredDataNoComponents",
+                {"instrument": inst},
+                run="test",
+            )
+            self.refs.append(ref)
+
+        # Store some datasets in the butler.
+        for i, ref in enumerate(self.refs):
+            m = MetricsExample({"something": i})
+            self.butler.put(m, ref)
+
+    def tearDown(self) -> None:
+        removeTestTempDir(self.root)
+
+    def test_empty_trash(self) -> None:
+        """Simple trash emptying.
+
+        Must use low-level API to prevent pruneDatasets from automatically
+        removing.
+        """
+        uris = [self.butler.getURI(ref) for ref in self.refs]
+        self.butler._datastore.trash(self.refs)
+        self.butler._registry.removeDatasets(self.refs)
+
+        for uri in uris:
+            self.assertTrue(uri.exists())
+
+        # Pretend to remove.
+        with self.assertLogs(level="INFO") as cm:
+            empty_trash(self.root, dry_run=True, verbose=False)
+        self.assertIn("Would have Removed 10", "\n".join(cm.output))
+        for uri in uris:
+            self.assertTrue(uri.exists())
+
+        # Do the removal.
+        with self.assertLogs(level="INFO") as cm:
+            empty_trash(self.root, dry_run=False, verbose=False)
+        self.assertIn("Removed 10", "\n".join(cm.output))
+        for uri in uris:
+            self.assertFalse(uri.exists(), str(uri))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Forces the `Datastore.emptyTrash` API to be called.

Depends on lsst/daf_butler#1195